### PR TITLE
Make call to RemoteCache::new not async

### DIFF
--- a/src/key_caches/remote/tests/decrypt_unchecked.rs
+++ b/src/key_caches/remote/tests/decrypt_unchecked.rs
@@ -10,7 +10,8 @@ use crate::prelude::Error;
 /// If we see anything else, we reject it.
 async fn test_fail_invalid_algorithm() {
     let uri = "https://www.googleapis.com/oauth2/v2/certs";
-    let remote_cache = RemoteCache::new(uri).await.unwrap();
+    let mut remote_cache = RemoteCache::new(uri).unwrap();
+    remote_cache.refresh().await.unwrap();
 
     #[derive(Deserialize, Debug)]
     struct GoogleClaims;
@@ -33,7 +34,8 @@ async fn test_fail_invalid_algorithm() {
 /// The given token has the correct `alg`, but no `kid`.
 async fn test_fail_no_kid() {
     let uri = "https://www.googleapis.com/oauth2/v2/certs";
-    let remote_cache = RemoteCache::new(uri).await.unwrap();
+    let mut remote_cache = RemoteCache::new(uri).unwrap();
+    remote_cache.refresh().await.unwrap();
 
     #[derive(Deserialize, Debug)]
     struct GoogleClaims;
@@ -57,7 +59,8 @@ async fn test_fail_no_kid() {
 /// Therefore, a lookup for a matching `kid` value will fail.
 async fn test_fail_no_corresponding_kid() {
     let uri = "https://www.facebook.com/.well-known/oauth/openid/jwks/";
-    let remote_cache = RemoteCache::new(uri).await.unwrap();
+    let mut remote_cache = RemoteCache::new(uri).unwrap();
+    remote_cache.refresh().await.unwrap();
 
     #[derive(Deserialize, Debug)]
     struct GoogleClaims;
@@ -76,7 +79,8 @@ async fn test_fail_no_corresponding_kid() {
 /// containing a valid `alg` and a valid `kid` but is an invalid signature.
 async fn test_fail_decryption() {
     let uri = "https://www.facebook.com/.well-known/oauth/openid/jwks/";
-    let remote_cache = RemoteCache::new(uri).await.unwrap();
+    let mut remote_cache = RemoteCache::new(uri).unwrap();
+    remote_cache.refresh().await.unwrap();
 
     #[derive(Deserialize, Debug)]
     struct GoogleClaims;
@@ -94,7 +98,8 @@ async fn test_fail_decryption() {
 #[tokio::test]
 async fn test() {
     let uri = "https://www.googleapis.com/oauth2/v2/certs";
-    let remote_cache = RemoteCache::new(uri).await.unwrap();
+    let mut remote_cache = RemoteCache::new(uri).unwrap();
+    remote_cache.refresh().await.unwrap();
 
     #[derive(Deserialize, Debug)]
     struct GoogleClaims {}

--- a/src/key_caches/remote/tests/new.rs
+++ b/src/key_caches/remote/tests/new.rs
@@ -8,12 +8,18 @@ use crate::prelude::GOOGLE_JWK_URI;
 ///
 /// This will ensure that the [`fetch`] function works too.
 async fn test_creation() {
-    let uri = FACEBOOK_JWK_URI;
-    let _ = RemoteCache::new(uri).await.unwrap();
+    let uris = vec![
+        FACEBOOK_JWK_URI,
+        GOOGLE_JWK_URI,
+        APPLE_JWK_URI,
+    ];
 
-    let uri = APPLE_JWK_URI;
-    let _ = RemoteCache::new(uri).await.unwrap();
+    for uri in uris {
+        let mut remote_cache = RemoteCache::new(uri).unwrap();
 
-    let uri = GOOGLE_JWK_URI;
-    let _ = RemoteCache::new(uri).await.unwrap();
+        let is_fresh = remote_cache.is_cache_fresh();
+        assert!(!is_fresh);
+
+        remote_cache.refresh().await.unwrap();
+    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,15 +30,25 @@
 //! let facebooks_jwks_url = "https://...";
 //! let apples_jwks_url = "https://...";
 //!
-//! let mut remote_cache_google = RemoteCache::new(googles_jwks_url).await?;
-//! let mut remote_cache_facebook = RemoteCache::new(facebooks_jwks_url).await?;
-//! let mut remote_cache_apple = RemoteCache::new(apples_jwks_url).await?;
+//! let mut remote_cache_google = RemoteCache::new(googles_jwks_url)?;
+//! let mut remote_cache_facebook = RemoteCache::new(facebooks_jwks_url)?;
+//! let mut remote_cache_apple = RemoteCache::new(apples_jwks_url)?;
+//!
+//! // Upon instantiation, caches will *always* be stale.
+//! // Therefore, you need to refresh them first!
+//!
+//! remote_cache_google.refresh().await?;
+//! remote_cache_facebook.refresh().await?;
+//! remote_cache_apple.refresh().await?;
+//!
+//! // Now assume that an arbitrary amount of time has passed!
+//! // We don't know if the keys inside the cache are still valid...
 //!
 //! // Incoming token to be verified!
 //! // Token is claimed to be signed by `Google`!
 //! let token = "a.b.c";
 //!
-//! // check to make sure the cache is fresh...
+//! // Check to make sure the cache is fresh...
 //! let is_fresh = remote_cache_google.is_fresh();
 //!
 //! // If the cache is *not* fresh, refresh it!
@@ -46,7 +56,7 @@
 //!     remote_cache.refresh().await?;
 //! };
 //!
-//! // decrypt the incoming token!
+//! // Decrypt the incoming token!
 //! let jsonwebtoken::TokenData { claims: GoogleClaims { .. }, .. } = remote_cache_google.decrypt_unchecked::<GoogleClaims, _>(token)?;
 //! ```
 //!


### PR DESCRIPTION
- Instead, the call just instantiates the URI and an empty BTreeMap
    - However, the next call to decrypt_unchecked should check whether
    or not the cache is stale.
        - Right after instantiation, `is_cache_fresh` will immediately
        return false
        - therefore, we perform a network call THEN
- This change was made so that we can bind an instance of `RemoteCache`
to a `lazy_static` *without* having to make an asynchronous call!

- edited the doc examples that I found...
    - there may be more remaining, idk...