### PR TITLE
Add ability to give `kid` when instantiating

### DIFF
--- a/src/key_caches/local/mod.rs
+++ b/src/key_caches/local/mod.rs
@@ -34,11 +34,11 @@ impl LocalCache {
 
     pub fn add_key(
         &mut self,
+        kid: Uuid,
         encoding_key: EncodingKey,
         decoding_key: DecodingKey,
-    ) -> Uuid {
+    ) {
         let Self { keys, .. } = self;
-        let kid = Uuid::new_v4();
         let _ = keys.insert(kid, (encoding_key, decoding_key));
 
         kid


### PR DESCRIPTION
- A local cache should allow the user to specify the `kid` of the key
that they want to use
    - now a local cache can only be created by passing a `kid`,
    DecodingKey, and an EncodingKey